### PR TITLE
Make FLAC tags matching case insensitive & add 'track number" as poss…

### DIFF
--- a/lib/Lltag/FLAC.pm
+++ b/lib/Lltag/FLAC.pm
@@ -23,8 +23,9 @@ sub read_tags {
 	if $status ;
     @output = map {
 	my $line = $_ ;
-	$line =~ s/^\s*comment\[\d+\]\s*:\s*(.*)/$1/ ;
-	$line =~ s/^TRACKNUMBER=/NUMBER=/ ;
+	$line =~ s/^\s*comment\[\d+\]\s*:\s*(.*)/$1/i ;
+	$line =~ s/^tracknumber=/NUMBER=/i ;
+	$line =~ s/^track number=/NUMBER=/i ;
 	$line
 	} ( grep { /comment\[\d+\]/ } @output ) ;
     return Lltag::Tags::convert_tag_stream_to_values ($self, @output) ;


### PR DESCRIPTION
…ible tag

IItag often fails to match when the flac tag is the lowercase "tracknumber," or "track number" regardless of case.  Adding '/i' to the end of the Perl regex makes matching case insensitive.