### PR TITLE
Make field regex lazy, so = in the value doesn't get matched

### DIFF
--- a/lib/Lltag/Tags.pm
+++ b/lib/Lltag/Tags.pm
@@ -201,7 +201,7 @@ sub convert_tag_stream_to_values {
 
     while (my $line = shift @_) {
 	chomp $line ;
-	my ($field, $value) = ($line =~ m/^(.*)=(.*)$/) ;
+	my ($field, $value) = ($line =~ m/^(.*?)=(.*)$/) ;
 	next if !$value ;
 
 	# remove the track total from the track number to avoid renaming problems with slashes or so


### PR DESCRIPTION
I have track with the title `Only Death = Quiet` which I tried to rename, which gave the following error:

```
Processing file "Urban Guerrilla - Action Directe - 14 Only Death = Quiet.flac"...
  Tagging.
  Renaming with format '%A/%n. %a - %t'...
    WARNING: Undefined field 'TITLE'
    New filename is 'Action Directe/14. Urban Guerrilla - .flac'
```
Querying the tag list showed the following

```
eater@adora: ~/music/Action Directe $ lltag -v 14.\ Urban\ Guerrilla\ -\ .flac

Processing file "14. Urban Guerrilla - .flac"...
  Trying to parse filename with internal formats...
Did not find any format file.
  Didn't find any parser!
    Current tag values are:
      ARTIST: Urban Guerrilla
      ALBUM: Action Directe
      NUMBER: 14
      DATE: 1998
      COMMENT: Visit http://fffmusic.bandcamp.com
      TITLE=Only Death :  Quiet
      ALBUMARTIST: FFF / Urban Guerrilla
```

It's currently seeing the first `=` as part of the field name, since the regex for it is greedy, by making it lazy it now results in

```
eater@adora: ~/music $ lltag -S 'Action Directe/14. Urban Guerrilla - Only Death = Quiet.flac' | grep TITLE
  TITLE=Only Death = Quiet
```
```