### PR TITLE
Make Ogg tags matching case insensitive

### DIFF
--- a/lib/Lltag/OGG.pm
+++ b/lib/Lltag/OGG.pm
@@ -22,7 +22,7 @@ sub read_tags {
 	if $status ;
     @output = map {
 	my $line = $_ ;
-	$line =~ s/^TRACKNUMBER=/NUMBER=/ ;
+	$line =~ s/^TRACKNUMBER=/NUMBER=/i ;
 	$line
 	} @output ;
     return Lltag::Tags::convert_tag_stream_to_values ($self, @output) ;


### PR DESCRIPTION
Turns out lowercase Ogg tags are also seen in the wild.
Patch inspired by b8b618033623d5691f2644459061ca345cce9653